### PR TITLE
Add User model, GraphQL reader endpoints

### DIFF
--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,11 +1,3 @@
 Types::MutationType = GraphQL::ObjectType.define do
   name "Mutation"
-
-  # TODO: Remove me
-  field :testField, types.String do
-    description "An example field added by the generator"
-    resolve ->(_obj, _args, _ctx) {
-      "Hello World!"
-    }
-  end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,11 +3,19 @@ Types::QueryType = GraphQL::ObjectType.define do
   # Add root-level fields here.
   # They will be entry points for queries on your schema.
 
-  # TODO: remove me
-  field :testField, types.String do
-    description "An example field added by the generator"
+  field :users, !types[Types::UserType] do
+    description "All users"
     resolve ->(_obj, _args, _ctx) {
-      "Hello World!"
+      User.all
+    }
+  end
+
+  field :user do
+    type Types::UserType
+    argument :email, !types.String
+    description "Find a user by email"
+    resolve ->(_obj, args, _ctx) {
+      User.find_by_email(args["email"])
     }
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,0 +1,8 @@
+Types::UserType = GraphQL::ObjectType.define do
+  name 'User'
+  description "A user who is able to sign."
+
+  field :id, !types.ID
+  field :email, !types.String
+  field :username, !types.String
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,20 @@
+class User < ApplicationRecord
+	validates :email,
+		presence: true,
+		format: {
+			with: /.*@.*\..*/,
+			message: "Must be a valid email address"
+		},
+		length: {
+			minimum: 6,
+			maximum: 100
+		}
+
+	validates :username,
+		presence: true,
+		uniqueness: true,
+		length: {
+			minimum: 1,
+			maximum: 50
+		}
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,20 +1,20 @@
 class User < ApplicationRecord
-	validates :email,
-		presence: true,
-		format: {
-			with: /.*@.*\..*/,
-			message: "Must be a valid email address"
-		},
-		length: {
-			minimum: 6,
-			maximum: 100
-		}
+  validates :email,
+    presence: true,
+    format: {
+      with: /.*@.*\..*/,
+      message: "Must be a valid email address"
+    },
+    length: {
+      minimum: 6,
+      maximum: 100
+    }
 
-	validates :username,
-		presence: true,
-		uniqueness: true,
-		length: {
-			minimum: 1,
-			maximum: 50
-		}
+  validates :username,
+    presence: true,
+    uniqueness: true,
+    length: {
+      minimum: 1,
+      maximum: 50
+    }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   validates :email,
     presence: true,
     format: {
-      with: /.*@.*\..*/,
+      with: /\A.*@.*\..*\z/,
       message: "Must be a valid email address"
     },
     length: {

--- a/db/migrate/20170909211411_create_users.rb
+++ b/db/migrate/20170909211411_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170909213346_add_username_to_users.rb
+++ b/db/migrate/20170909213346_add_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.1]
+  def change
+  	add_column :users, :username, :string
+  	add_index :users, :username, unique: true
+  end
+end

--- a/db/migrate/20170909213346_add_username_to_users.rb
+++ b/db/migrate/20170909213346_add_username_to_users.rb
@@ -1,6 +1,6 @@
 class AddUsernameToUsers < ActiveRecord::Migration[5.1]
   def change
-  	add_column :users, :username, :string
-  	add_index :users, :username, unique: true
+    add_column :users, :username, :string
+    add_index :users, :username, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20170909213346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "username"
+    t.index ["username"], name: "index_users_on_username", unique: true
+  end
 
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: MyString
+
+two:
+  email: MyString

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Adds a User model to store emails and usernames, with appropriate validations. Adds two GraphQL endpoints:

- `/users`: Returns a list of all users
- `/user`: Given an email, returns that user

TG-6 #code-review